### PR TITLE
Cassandra 17342 Performance problem for node restart with incremental range repairs

### DIFF
--- a/src/java/org/apache/cassandra/repair/consistent/LocalSessions.java
+++ b/src/java/org/apache/cassandra/repair/consistent/LocalSessions.java
@@ -241,7 +241,7 @@ public class LocalSessions
             TableId tid = entry.getKey();
             RepairedState state = getRepairedState(tid);
             state.add(entry.getValue());
-    	    }
+        }
     }
 
     /**

--- a/src/java/org/apache/cassandra/repair/consistent/LocalSessions.java
+++ b/src/java/org/apache/cassandra/repair/consistent/LocalSessions.java
@@ -365,7 +365,7 @@ public class LocalSessions
             {
                 LocalSession session = load(row);
                 loadedSessions.put(session.sessionID, session);
-                if (!shouldStoreSession(session)) 
+                if (shouldStoreSession(session)) 
                 {
                     for (TableId tid : session.tableIds)
                     {

--- a/src/java/org/apache/cassandra/repair/consistent/LocalSessions.java
+++ b/src/java/org/apache/cassandra/repair/consistent/LocalSessions.java
@@ -219,7 +219,6 @@ public class LocalSessions
         for (TableId tid : session.tableIds)
         {
             RepairedState state = getRepairedState(tid);
-            // During initial start up batch the data together and process it later 
             state.add(session.ranges, session.repairedAt);
         }
     }
@@ -237,9 +236,10 @@ public class LocalSessions
     }
     private void finaliseStates( Map<TableId, List<RepairedState.Level>> initialLevels)
     {
-        for (Map.Entry<TableId, List<RepairedState.Level>> entry : initialLevels.entrySet()) {
-    		    TableId tid = entry.getKey();
-    		    RepairedState state = getRepairedState(tid);
+        for (Map.Entry<TableId, List<RepairedState.Level>> entry : initialLevels.entrySet()) 
+        {
+            TableId tid = entry.getKey();
+            RepairedState state = getRepairedState(tid);
             state.add(entry.getValue());
     	    }
     }

--- a/src/java/org/apache/cassandra/repair/consistent/LocalSessions.java
+++ b/src/java/org/apache/cassandra/repair/consistent/LocalSessions.java
@@ -111,9 +111,7 @@ import static org.apache.cassandra.repair.consistent.ConsistentSession.State.*;
  */
 public class LocalSessions
 {
-//    private static final java.util.logging.Logger logger = LoggerFactory.getLogger(LocalSessions.class);
     private static final Logger logger = LoggerFactory.getLogger(LocalSessions.class);
-
     private static final Set<Listener> listeners = new CopyOnWriteArraySet<>();
 
     /**
@@ -351,18 +349,11 @@ public class LocalSessions
     {
         Preconditions.checkArgument(!started, "LocalSessions.start can only be called once");
         Preconditions.checkArgument(sessions.isEmpty(), "No sessions should be added before start");
-        logger.info("In Start method");
         UntypedResultSet rows = QueryProcessor.executeInternalWithPaging(String.format("SELECT * FROM %s.%s", keyspace, table), 1000);
         Map<UUID, LocalSession> loadedSessions = new HashMap<>();
-        
-        Integer rowcount = 0;
         for (UntypedResultSet.Row row : rows)
         {
-        	    rowcount++;
-        	    if (rowcount % 1000 == 0)
-        	    		logger.info("Reading row {} ", rowcount);
-            
-            try
+             try
             {
                 LocalSession session = load(row);
                 maybeUpdateRepairedState(session);
@@ -375,9 +366,7 @@ public class LocalSessions
                     deleteRow(row.getUUID("parent_id"));
             }
         }
-        logger.info("Read all rows");
         finaliseStates();
-        logger.info("States all finalised");
         
         sessions = ImmutableMap.copyOf(loadedSessions);
         failOngoingRepairs();

--- a/src/java/org/apache/cassandra/repair/consistent/LocalSessions.java
+++ b/src/java/org/apache/cassandra/repair/consistent/LocalSessions.java
@@ -353,7 +353,7 @@ public class LocalSessions
         Map<UUID, LocalSession> loadedSessions = new HashMap<>();
         for (UntypedResultSet.Row row : rows)
         {
-             try
+            try
             {
                 LocalSession session = load(row);
                 maybeUpdateRepairedState(session);

--- a/src/java/org/apache/cassandra/repair/consistent/RepairedState.java
+++ b/src/java/org/apache/cassandra/repair/consistent/RepairedState.java
@@ -201,7 +201,6 @@ public class RepairedState
     }
 
     private volatile State state = new State(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-    private volatile List<Level>  initalLevels = new LinkedList<>();
 
     State state()
     {
@@ -221,18 +220,6 @@ public class RepairedState
         sections.sort(Section.tokenComparator);
         return sections;
     }
-    /**
-     * Create and store a Level, this should be used during start up, and the finaliseInitalLevels should be called 
-     * 
-     * @param ranges
-     * @param repairedAt
-     */
-    public void storeInitialLevel(Collection<Range<Token>> ranges, long repairedAt)
-    {
-        Level newLevel = new Level(ranges, repairedAt);
-        initalLevels.add(newLevel);
-    }
-
     public void add( List<Level> newLevels)
     {
         State lastState = state;
@@ -278,16 +265,10 @@ public class RepairedState
     public synchronized void add(Collection<Range<Token>> ranges, long repairedAt)
     {
         Level newLevel = new Level(ranges, repairedAt);
-
-        State lastState = state;
-
-        List<Level> tmp = new ArrayList<>(lastState.levels.size() + 1);
-        tmp.addAll(lastState.levels);
-        tmp.add(newLevel);
-        tmp.sort(Level.timeComparator);
-
-        processLevels(tmp);
-
+        List<Level> levels = new LinkedList<Level>();
+        levels.add(newLevel);
+        add(levels);
+ 
      }
 
     public long minRepairedAt(Collection<Range<Token>> ranges)

--- a/src/java/org/apache/cassandra/repair/consistent/RepairedState.java
+++ b/src/java/org/apache/cassandra/repair/consistent/RepairedState.java
@@ -41,9 +41,6 @@ import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.service.ActiveRepairService;
 import org.apache.cassandra.utils.UUIDGen;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import static org.apache.cassandra.service.ActiveRepairService.UNREPAIRED_SSTABLE;
 
 /**
@@ -234,8 +231,8 @@ public class RepairedState
     {
         Level newLevel = new Level(ranges, repairedAt);
         initalLevels.add(newLevel);
-    	
     }
+
     public void finaliseInitalLevels()
     {
         State lastState = state;

--- a/src/java/org/apache/cassandra/repair/consistent/RepairedState.java
+++ b/src/java/org/apache/cassandra/repair/consistent/RepairedState.java
@@ -247,8 +247,8 @@ public class RepairedState
 
 	private void processLevels(List<Level> tmp) {
 
-		List<Level> levels = new ArrayList<>(tmp.size() );
-		List<Range<Token>> covered = new ArrayList<>();
+        List<Level> levels = new ArrayList<>(tmp.size() );
+        List<Range<Token>> covered = new ArrayList<>();
 
         for (Level level : tmp)
         {

--- a/src/java/org/apache/cassandra/repair/consistent/RepairedState.java
+++ b/src/java/org/apache/cassandra/repair/consistent/RepairedState.java
@@ -56,8 +56,6 @@ import static org.apache.cassandra.service.ActiveRepairService.UNREPAIRED_SSTABL
  */
 public class RepairedState
 {
-  private static final Logger logger = LoggerFactory.getLogger(RepairedState.class);
-
     static class Level
     {
         final List<Range<Token>> ranges;
@@ -240,7 +238,6 @@ public class RepairedState
     }
     public void finaliseInitalLevels()
     {
- 
         State lastState = state;
 
         List<Level> levels = new ArrayList<>(lastState.levels.size() + initalLevels.size());
@@ -254,7 +251,6 @@ public class RepairedState
 	private void processLevels(List<Level> tmp) {
 
 		List<Level> levels = new ArrayList<>(tmp.size() );
-
 		List<Range<Token>> covered = new ArrayList<>();
 
         for (Level level : tmp)
@@ -278,8 +274,6 @@ public class RepairedState
             }
         }
         sections.sort(Section.tokenComparator);
-        
-        
 
         state = new State(levels, covered, sections);
         

--- a/src/java/org/apache/cassandra/repair/consistent/RepairedState.java
+++ b/src/java/org/apache/cassandra/repair/consistent/RepairedState.java
@@ -233,18 +233,18 @@ public class RepairedState
         initalLevels.add(newLevel);
     }
 
-    public void finaliseInitalLevels()
+    public void add( List<Level> newLevels)
     {
         State lastState = state;
 
-        List<Level> levels = new ArrayList<>(lastState.levels.size() + initalLevels.size());
+        List<Level> levels = new ArrayList<>(lastState.levels.size() + newLevels.size());
         levels.addAll(lastState.levels);
-        levels.addAll(initalLevels);
+        levels.addAll(newLevels);
         levels.sort(Level.timeComparator);
 
         processLevels(levels);
     }
-
+    
 	private void processLevels(List<Level> tmp) {
 
         List<Level> levels = new ArrayList<>(tmp.size() );

--- a/test/unit/org/apache/cassandra/repair/consistent/BulkRepairStateTest.java
+++ b/test/unit/org/apache/cassandra/repair/consistent/BulkRepairStateTest.java
@@ -28,7 +28,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
-
+/*
 public class BulkRepairStateTest {
 	   private static Token tk(long t)
 	    {
@@ -157,3 +157,4 @@ public class BulkRepairStateTest {
 
 
 }
+*/

--- a/test/unit/org/apache/cassandra/repair/consistent/BulkRepairStateTest.java
+++ b/test/unit/org/apache/cassandra/repair/consistent/BulkRepairStateTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.cassandra.repair.consistent;
 
 import java.util.ArrayList;

--- a/test/unit/org/apache/cassandra/repair/consistent/BulkRepairStateTest.java
+++ b/test/unit/org/apache/cassandra/repair/consistent/BulkRepairStateTest.java
@@ -1,0 +1,142 @@
+package org.apache.cassandra.repair.consistent;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.dht.Range;
+import org.apache.cassandra.dht.Token;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+
+public class BulkRepairStateTest {
+	   private static Token tk(long t)
+	    {
+	        return new Murmur3Partitioner.LongToken(t);
+	    }
+
+	    private static Range<Token> range(long left, long right)
+	    {
+	        return new Range<>(tk(left), tk(right));
+	    }
+
+	    private static List<Range<Token>> ranges(long... tokens)
+	    {
+	        assert tokens.length %2 == 0;
+	        List<Range<Token>> ranges = new ArrayList<>();
+	        for (int i=0; i<tokens.length; i+=2)
+	        {
+	            ranges.add(range(tokens[i], tokens[i+1]));
+
+	        }
+	        return ranges;
+	    }
+
+	    private static RepairedState.Level level(Collection<Range<Token>> ranges, long repairedAt)
+	    {
+	        return new RepairedState.Level(ranges, repairedAt);
+	    }
+
+	    private static RepairedState.Section sect(Range<Token> range, long repairedAt)
+	    {
+	        return new RepairedState.Section(range, repairedAt);
+	    }
+
+	    private static RepairedState.Section sect(int l, int r, long time)
+	    {
+	        return sect(range(l, r), time);
+	    }
+
+	    private static <T> List<T> l(T... contents)
+	    {
+	        return Lists.newArrayList(contents);
+	    }
+
+	    @Test
+	    public void mergeOverlapping()
+	    {
+	        RepairedState repairs = new RepairedState();
+
+	        repairs.storeInitialLevel(ranges(100, 300), 5);
+	        repairs.storeInitialLevel(ranges(200, 400), 6);
+	        repairs.finaliseInitalLevels();
+
+	        RepairedState.State state = repairs.state();
+	        Assert.assertEquals(l(level(ranges(200, 400), 6), level(ranges(100, 200), 5)), state.levels);
+	        Assert.assertEquals(l(sect(range(100, 200), 5), sect(range(200, 400), 6)), state.sections);
+	        Assert.assertEquals(ranges(100, 400), state.covered);
+	    }
+
+	    @Test
+	    public void mergeSameRange()
+	    {
+	        RepairedState repairs = new RepairedState();
+
+	        repairs.storeInitialLevel(ranges(100, 400), 5);
+	        repairs.storeInitialLevel(ranges(100, 400), 6);
+	        repairs.finaliseInitalLevels();
+
+	        RepairedState.State state = repairs.state();
+	        Assert.assertEquals(l(level(ranges(100, 400), 6)), state.levels);
+	        Assert.assertEquals(l(sect(range(100, 400), 6)), state.sections);
+	        Assert.assertEquals(ranges(100, 400), state.covered);
+	    }
+
+	    @Test
+	    public void mergeLargeRange()
+	    {
+	        RepairedState repairs = new RepairedState();
+
+	        repairs.storeInitialLevel(ranges(200, 300), 5);
+	        repairs.storeInitialLevel(ranges(100, 400), 6);
+	        repairs.finaliseInitalLevels();
+
+	        RepairedState.State state = repairs.state();
+	        Assert.assertEquals(l(level(ranges(100, 400), 6)), state.levels);
+	        Assert.assertEquals(l(sect(range(100, 400), 6)), state.sections);
+	        Assert.assertEquals(ranges(100, 400), state.covered);
+	    }
+
+	    @Test
+	    public void mergeSmallRange()
+	    {
+	        RepairedState repairs = new RepairedState();
+
+	        repairs.storeInitialLevel(ranges(100, 400), 5);
+	        repairs.storeInitialLevel(ranges(200, 300), 6);
+	        repairs.finaliseInitalLevels();
+
+	        RepairedState.State state = repairs.state();
+	        Assert.assertEquals(l(level(ranges(200, 300), 6), level(ranges(100, 200, 300, 400), 5)), state.levels);
+	        Assert.assertEquals(l(sect(range(100, 200), 5), sect(range(200, 300), 6), sect(range(300, 400), 5)), state.sections);
+	        Assert.assertEquals(ranges(100, 400), state.covered);
+	    }
+
+
+	    @Test
+	    public void repairedAt()
+	    {
+	        RepairedState rs;
+
+	        // overlapping
+	        rs = new RepairedState();
+	        rs.storeInitialLevel(ranges(100, 300), 5);
+	        rs.storeInitialLevel(ranges(200, 400), 6);
+	        rs.finaliseInitalLevels();
+
+	        Assert.assertEquals(5, rs.minRepairedAt(ranges(150, 250)));
+	        Assert.assertEquals(5, rs.minRepairedAt(ranges(150, 160)));
+	        Assert.assertEquals(5, rs.minRepairedAt(ranges(100, 200)));
+	        Assert.assertEquals(6, rs.minRepairedAt(ranges(200, 400)));
+	        Assert.assertEquals(0, rs.minRepairedAt(ranges(200, 401)));
+	        Assert.assertEquals(0, rs.minRepairedAt(ranges(99, 200)));
+	        Assert.assertEquals(0, rs.minRepairedAt(ranges(50, 450)));
+	        Assert.assertEquals(0, rs.minRepairedAt(ranges(50, 60)));
+	        Assert.assertEquals(0, rs.minRepairedAt(ranges(450, 460)));
+	    }
+
+
+}

--- a/test/unit/org/apache/cassandra/repair/consistent/BulkRepairStateTest.java
+++ b/test/unit/org/apache/cassandra/repair/consistent/BulkRepairStateTest.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.repair.consistent;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.cassandra.dht.Murmur3Partitioner;
@@ -28,7 +29,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
-/*
+
 public class BulkRepairStateTest {
 	   private static Token tk(long t)
 	    {
@@ -76,25 +77,24 @@ public class BulkRepairStateTest {
 	    public void mergeOverlapping()
 	    {
 	        RepairedState repairs = new RepairedState();
-
-	        repairs.storeInitialLevel(ranges(100, 300), 5);
-	        repairs.storeInitialLevel(ranges(200, 400), 6);
-	        repairs.finaliseInitalLevels();
+	        List<RepairedState.Level> list = new LinkedList<RepairedState.Level>();
+            list.add( new RepairedState.Level(ranges(100, 300), 5 ));
+            list.add( new RepairedState.Level(ranges(200, 400), 6 ));
+	        repairs.add(list);
 
 	        RepairedState.State state = repairs.state();
 	        Assert.assertEquals(l(level(ranges(200, 400), 6), level(ranges(100, 200), 5)), state.levels);
 	        Assert.assertEquals(l(sect(range(100, 200), 5), sect(range(200, 400), 6)), state.sections);
 	        Assert.assertEquals(ranges(100, 400), state.covered);
 	    }
-
 	    @Test
 	    public void mergeSameRange()
 	    {
 	        RepairedState repairs = new RepairedState();
-
-	        repairs.storeInitialLevel(ranges(100, 400), 5);
-	        repairs.storeInitialLevel(ranges(100, 400), 6);
-	        repairs.finaliseInitalLevels();
+            List<RepairedState.Level> list = new LinkedList<RepairedState.Level>();
+            list.add( new RepairedState.Level(ranges(100, 400), 5 ));
+            list.add( new RepairedState.Level(ranges(100, 400), 6 ));
+            repairs.add(list);
 
 	        RepairedState.State state = repairs.state();
 	        Assert.assertEquals(l(level(ranges(100, 400), 6)), state.levels);
@@ -107,9 +107,10 @@ public class BulkRepairStateTest {
 	    {
 	        RepairedState repairs = new RepairedState();
 
-	        repairs.storeInitialLevel(ranges(200, 300), 5);
-	        repairs.storeInitialLevel(ranges(100, 400), 6);
-	        repairs.finaliseInitalLevels();
+            List<RepairedState.Level> list = new LinkedList<RepairedState.Level>();
+            list.add( new RepairedState.Level(ranges(200, 300), 5 ));
+            list.add( new RepairedState.Level(ranges(100, 400), 6 ));
+            repairs.add(list);
 
 	        RepairedState.State state = repairs.state();
 	        Assert.assertEquals(l(level(ranges(100, 400), 6)), state.levels);
@@ -122,9 +123,10 @@ public class BulkRepairStateTest {
 	    {
 	        RepairedState repairs = new RepairedState();
 
-	        repairs.storeInitialLevel(ranges(100, 400), 5);
-	        repairs.storeInitialLevel(ranges(200, 300), 6);
-	        repairs.finaliseInitalLevels();
+	        List<RepairedState.Level> list = new LinkedList<RepairedState.Level>();
+	        list.add( new RepairedState.Level(ranges(100, 400), 5 ));
+            list.add( new RepairedState.Level(ranges(200, 300), 6 ));
+            repairs.add(list);
 
 	        RepairedState.State state = repairs.state();
 	        Assert.assertEquals(l(level(ranges(200, 300), 6), level(ranges(100, 200, 300, 400), 5)), state.levels);
@@ -140,9 +142,10 @@ public class BulkRepairStateTest {
 
 	        // overlapping
 	        rs = new RepairedState();
-	        rs.storeInitialLevel(ranges(100, 300), 5);
-	        rs.storeInitialLevel(ranges(200, 400), 6);
-	        rs.finaliseInitalLevels();
+            List<RepairedState.Level> list = new LinkedList<RepairedState.Level>();
+            list.add( new RepairedState.Level(ranges(100, 300), 5 ));
+            list.add( new RepairedState.Level(ranges(200, 400), 6 ));
+            rs.add(list);
 
 	        Assert.assertEquals(5, rs.minRepairedAt(ranges(150, 250)));
 	        Assert.assertEquals(5, rs.minRepairedAt(ranges(150, 160)));
@@ -157,4 +160,4 @@ public class BulkRepairStateTest {
 
 
 }
-*/
+


### PR DESCRIPTION
Improving start up processing of Incremental Repair information read from system.repairs